### PR TITLE
Version 0.3.1 hotfixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,7 +181,7 @@ dependencies = [
 
 [[package]]
 name = "av-denoise"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "av-decoders",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "av-denoise"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 description = "Fast and efficient video denoising using accelerated nlmeans."
 categories = ["multimedia::video"]

--- a/benches/kernels/copy.rs
+++ b/benches/kernels/copy.rs
@@ -38,6 +38,8 @@ impl<R: Runtime> Benchmark for CopyBench<R> {
                 CubeDim::new_1d(BLOCK_1D),
                 ArrayArg::from_raw_parts(args.src.clone(), len),
                 ArrayArg::from_raw_parts(args.dst.clone(), len),
+                0u32,
+                0u32,
                 len as u32,
                 total_threads,
             );

--- a/benches/kernels/finish.rs
+++ b/benches/kernels/finish.rs
@@ -71,6 +71,7 @@ impl<R: Runtime> Benchmark for FinishBench<R> {
                 ArrayArg::from_raw_parts(args.weight_sum.clone(), pixels),
                 ArrayArg::from_raw_parts(args.max_weight.clone(), pixels),
                 0u32,
+                0u32,
                 1.0f32,
                 W,
                 H,

--- a/benches/nlmeans.rs
+++ b/benches/nlmeans.rs
@@ -261,6 +261,7 @@ fn bench_finish<R: Runtime>(client: &ComputeClient<R>, backend: &str, ch: u32, c
             ArrayArg::from_raw_parts(weight_sum.clone(), pixels),
             ArrayArg::from_raw_parts(max_weight.clone(), pixels),
             0u32,
+            0u32,
             1.0f32,
             W,
             H,

--- a/src/bin/cli/mod.rs
+++ b/src/bin/cli/mod.rs
@@ -79,7 +79,7 @@ pub fn resolve_channel_intent(modes: &[CliChannelMode]) -> Result<BinaryChannelI
 }
 
 #[derive(Debug, Parser)]
-#[command(about = "Fast and efficient video denoising", long_about = None)]
+#[command(about = "Fast and efficient video denoising", long_about = None, version)]
 pub struct Args {
     /// Speed vs quality dial.
     ///

--- a/src/nlmeans/align.rs
+++ b/src/nlmeans/align.rs
@@ -1,0 +1,102 @@
+use cubecl::prelude::*;
+
+/// Byte alignment every buffer binding must start on, taken from the
+/// runtime the denoiser is running against.
+///
+/// A GPU rejects a bind group whose buffer offset isn't a multiple of
+/// its `min_storage_buffer_offset_alignment`, so every buffer this
+/// crate slices into per-slot regions pads its slot stride up to this
+/// value. Backends report their own figure (32 bytes on the Vulkan
+/// adapters we test against, up to 256 elsewhere), which is why it's
+/// read from the runtime rather than assumed.
+///
+/// Carried as its own type rather than a bare `u64` so it can't be
+/// transposed with the width, height, or frame-count arguments it
+/// travels alongside.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct StorageAlign(u64);
+
+impl StorageAlign {
+    /// The alignment `client`'s runtime requires. cubecl aligns every
+    /// allocation it hands out to this same value, so a slot offset
+    /// that is a multiple of it lands on a boundary the backend
+    /// accepts.
+    pub(crate) fn from_client<R: Runtime>(client: &ComputeClient<R>) -> Self {
+        Self::new(client.properties().memory.alignment)
+    }
+
+    /// A fixed alignment, for tests that have no runtime to ask.
+    pub(crate) fn new(bytes: u64) -> Self {
+        debug_assert!(
+            bytes.is_power_of_two(),
+            "storage alignment {bytes} is not a power of two"
+        );
+        Self(bytes.max(1))
+    }
+
+    /// `bytes` rounded up to the next aligned boundary.
+    pub(crate) fn pad_bytes(self, bytes: u64) -> u64 {
+        bytes.next_multiple_of(self.0)
+    }
+
+    /// A count of `T` rounded up so that many elements span a whole
+    /// number of alignment boundaries. Alignments are powers of two, so
+    /// for any `T` whose size divides the alignment this lands exactly
+    /// on a boundary; for a larger `T` the elements are already
+    /// aligned and the count is returned unchanged.
+    pub(crate) fn pad_elems<T>(self, elems: usize) -> usize {
+        let per_boundary = (self.0 as usize).div_ceil(size_of::<T>()).max(1);
+        elems.next_multiple_of(per_boundary)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pad_bytes_rounds_up_to_the_boundary() {
+        let align = StorageAlign::new(32);
+        assert_eq!(align.pad_bytes(0), 0);
+        assert_eq!(align.pad_bytes(1), 32);
+        assert_eq!(align.pad_bytes(32), 32);
+        assert_eq!(align.pad_bytes(33), 64);
+    }
+
+    #[test]
+    fn pad_elems_spans_whole_boundaries() {
+        // 32-byte boundaries hold 8 f32s.
+        let align = StorageAlign::new(32);
+        assert_eq!(align.pad_elems::<f32>(0), 0);
+        assert_eq!(align.pad_elems::<f32>(1), 8);
+        assert_eq!(align.pad_elems::<f32>(8), 8);
+        assert_eq!(align.pad_elems::<f32>(9), 16);
+    }
+
+    #[test]
+    fn pad_elems_tracks_a_larger_alignment() {
+        // A 256-byte boundary holds 64 f32s, so the same element count
+        // pads eight times further than it does at 32 bytes.
+        let align = StorageAlign::new(256);
+        assert_eq!(align.pad_elems::<f32>(1), 64);
+        assert_eq!(align.pad_elems::<f32>(64), 64);
+        assert_eq!(align.pad_elems::<f32>(65), 128);
+    }
+
+    #[test]
+    fn padded_element_counts_are_byte_aligned() {
+        for bytes in [4u64, 16, 32, 64, 256] {
+            let align = StorageAlign::new(bytes);
+            for elems in [1usize, 3, 7, 137, 24_660] {
+                let padded = align.pad_elems::<f32>(elems) as u64 * size_of::<f32>() as u64;
+                assert_eq!(padded % bytes, 0, "align {bytes}, {elems} elements");
+            }
+        }
+    }
+
+    #[test]
+    fn an_alignment_below_the_element_size_leaves_counts_alone() {
+        let align = StorageAlign::new(4);
+        assert_eq!(align.pad_elems::<f32>(3), 3);
+    }
+}

--- a/src/nlmeans/denoiser.rs
+++ b/src/nlmeans/denoiser.rs
@@ -3,6 +3,7 @@ use std::marker::PhantomData;
 use cubecl::prelude::*;
 use cubecl::server::Handle;
 
+use super::align::StorageAlign;
 use super::kernels::gpu_copy;
 use super::motion::{self, MotionCtx, MotionEstimation, build_pyramid_for_slot, run_pyramid_build};
 use super::noise::{
@@ -37,6 +38,9 @@ pub struct NlmDenoiser<R: Runtime> {
     pub(super) params: NlmParams,
     pub(super) width: u32,
     pub(super) height: u32,
+    /// Byte alignment every per-slot buffer view must start on, read
+    /// from `client`'s runtime at construction. See [`StorageAlign`].
+    pub(super) align: StorageAlign,
 
     /// Monotonic count of frames pushed; `% total_frames` is the next
     /// physical slot in `input_buf` to overwrite.
@@ -118,7 +122,7 @@ pub struct NlmDenoiser<R: Runtime> {
     pub(super) spatial_offset_lut: Handle,
 
     /// Stage-1 noise-estimate scratch ring, `total_frames` slots each
-    /// `noise_partials_slot_stride_bytes(width, height)` bytes. `Some`
+    /// [`noise_partials_slot_stride_bytes`] bytes wide. `Some`
     /// only when the noise level is measured automatically (`hq` is
     /// set and `sigma_override` is `None`). One slot per ring position
     /// keeps a slot's partials intact between the push that queues
@@ -226,6 +230,7 @@ impl<R: Runtime> NlmDenoiser<R> {
         validate_dimensions(width, height)
             .expect("unsupported frame dimensions; call validate_dimensions first to surface this as Result");
 
+        let align = StorageAlign::from_client(client);
         let stored_ch = params.channels.storage_count();
         let total_frames = params.total_frames();
         let pixels = (width * height) as usize;
@@ -286,7 +291,8 @@ impl<R: Runtime> NlmDenoiser<R> {
         // the estimate kernels.
         let auto_noise = params.hq.is_some_and(|hq| hq.sigma_override.is_none());
         let (noise_partials, noise_results) = if auto_noise {
-            let partials_ring_bytes = noise_partials_slot_stride_bytes(width, height) * total_frames as u64;
+            let partials_ring_bytes =
+                noise_partials_slot_stride_bytes(width, height, align) * total_frames as u64;
             let n_results = (total_frames * 4) as usize;
             (
                 Some(client.empty(partials_ring_bytes as usize)),
@@ -300,7 +306,13 @@ impl<R: Runtime> NlmDenoiser<R> {
         // temporal neighbour to diff against, so it stays inert at
         // temporal_radius = 0 even when auto noise estimation is on.
         let temporal_stats_buf = if auto_noise && params.temporal_radius >= 1 {
-            Some(client.empty(temporal_stats_buf_bytes(width, height, stored_ch, total_frames)))
+            Some(client.empty(temporal_stats_buf_bytes(
+                width,
+                height,
+                stored_ch,
+                total_frames,
+                align,
+            )))
         } else {
             None
         };
@@ -309,7 +321,7 @@ impl<R: Runtime> NlmDenoiser<R> {
         // active *and* the temporal window is non-trivial (k=0 path
         // would never touch them).
         let mc_ctx = if params.motion_compensation.is_active() && params.temporal_radius > 0 {
-            MotionCtx::new(params.motion_compensation, width, height)
+            MotionCtx::new(params.motion_compensation, width, height, align)
         } else {
             None
         };
@@ -329,7 +341,8 @@ impl<R: Runtime> NlmDenoiser<R> {
             };
             let neighbours = (2 * params.temporal_radius) as u64;
             let mv_field = client.empty((neighbours * ctx.mv_field_bytes_per_neighbour()) as usize);
-            let pyramid_pixels = motion::pyramid_pixels_per_frame(width, height, ctx.pyramid_levels);
+            let pyramid_pixels =
+                motion::pyramid_pixels_per_frame(width, height, ctx.pyramid_levels, ctx.align);
             let pyr_in_bytes = pyramid_pixels * total_frames as usize * size_of::<f32>();
             let pyr_in = client.empty(pyr_in_bytes);
             let pyr_ref = if use_reference {
@@ -377,7 +390,7 @@ impl<R: Runtime> NlmDenoiser<R> {
         // the MC-active case. It needs its own luma pyramid ring and a
         // block-match kernel per neighbour.
         let confidence_only_active = confidence_active && mc_ctx.is_none();
-        let confidence_ctx = confidence_only_active.then(|| MotionCtx::confidence_only(width, height));
+        let confidence_ctx = confidence_only_active.then(|| MotionCtx::confidence_only(width, height, align));
 
         // The confidence buffer piggybacks on whichever block geometry
         // is available, but only when confidence weighting is active.
@@ -395,7 +408,8 @@ impl<R: Runtime> NlmDenoiser<R> {
         let confidence_dummy = client.empty(size_of::<f32>());
 
         let (confidence_pyramid, confidence_mv_scratch) = if let Some(ctx) = confidence_ctx.as_ref() {
-            let pyramid_pixels = motion::pyramid_pixels_per_frame(width, height, ctx.pyramid_levels);
+            let pyramid_pixels =
+                motion::pyramid_pixels_per_frame(width, height, ctx.pyramid_levels, ctx.align);
             let pyr_bytes = pyramid_pixels * total_frames as usize * size_of::<f32>();
             let mv_scratch_len = ctx.mv_slots_per_neighbour() * 2 * size_of::<i32>();
             (Some(client.empty(pyr_bytes)), Some(client.empty(mv_scratch_len)))
@@ -415,6 +429,7 @@ impl<R: Runtime> NlmDenoiser<R> {
             params,
             width,
             height,
+            align,
             ring_head: 0,
             frames_loaded: 0,
             real_pushes: 0,
@@ -757,7 +772,7 @@ impl<R: Runtime> NlmDenoiser<R> {
             return;
         };
 
-        let stride = noise_partials_slot_stride_bytes(self.width, self.height);
+        let stride = noise_partials_slot_stride_bytes(self.width, self.height, self.align);
         let partials_slot = partials_buf.clone().offset_start((slot as u64) * stride);
 
         let ctx = NoiseCtx {
@@ -804,6 +819,7 @@ impl<R: Runtime> NlmDenoiser<R> {
             slot_prev,
             input_buf: &self.input_buf,
             stats_buf,
+            align: self.align,
         };
 
         run_temporal_noise_stats::<R>(&self.client, &ctx).expect("temporal noise stats dispatch failed");
@@ -825,6 +841,7 @@ impl<R: Runtime> NlmDenoiser<R> {
             self.height,
             self.params.channels.storage_count(),
             slot,
+            self.align,
         );
     }
 
@@ -981,9 +998,8 @@ impl<R: Runtime> NlmDenoiser<R> {
     /// Both handles are bound whole and the slots addressed by the
     /// kernel's own offset arguments. Binding a slot directly would
     /// need its byte offset to be a multiple of the GPU's
-    /// `min_storage_buffer_offset_alignment` (32 bytes), which a frame
-    /// stride only satisfies when `width * height * stored_ch` is a
-    /// multiple of 8.
+    /// `min_storage_buffer_offset_alignment`, which a
+    /// `width * height * stored_ch` frame stride meets only by luck.
     fn copy_frame_into_slot(
         &self,
         dst: &Handle,
@@ -1168,7 +1184,7 @@ impl<R: Runtime> NlmDenoiser<R> {
             .expect("noise_partials allocated when auto noise is active");
 
         let slot_len_bytes = partials_len(self.width, self.height) as u64 * size_of::<f32>() as u64;
-        let stride = noise_partials_slot_stride_bytes(self.width, self.height);
+        let stride = noise_partials_slot_stride_bytes(self.width, self.height, self.align);
         let total_bytes = self.params.total_frames() as u64 * stride;
         let start = (slot as u64) * stride;
         let end_trim = total_bytes - start - slot_len_bytes;
@@ -1210,6 +1226,7 @@ impl<R: Runtime> NlmDenoiser<R> {
             stored_ch,
             frame_count,
             slot,
+            self.align,
         )?;
 
         Ok(aggregate_temporal_noise_stats(

--- a/src/nlmeans/denoiser.rs
+++ b/src/nlmeans/denoiser.rs
@@ -562,7 +562,7 @@ impl<R: Runtime> NlmDenoiser<R> {
                 .create_from_slice(f32::as_bytes(&self.padding_scratch))
         };
 
-        self.copy_frame_into_slot(dst, &staging, slot);
+        self.copy_frame_into_slot(dst, slot, &staging, 0, 1);
     }
 
     fn run_prefilter_for_slot(&self, slot: usize) {
@@ -972,14 +972,29 @@ impl<R: Runtime> NlmDenoiser<R> {
         self.real_pushes += 1;
     }
 
-    /// GPU→GPU copy of one frame from `src` into `dst` at the given
-    /// physical slot. `dst` must have ring-buffer layout matching
+    /// GPU→GPU copy of one frame from `src`'s slot `src_slot` into
+    /// `dst`'s slot `slot`. `dst` must have ring-buffer layout matching
     /// `input_buf` (`total_frames * height * width * stored_ch`).
-    fn copy_frame_into_slot(&self, dst: &Handle, src: &Handle, slot: usize) {
+    /// `src_slots` is how many frames `src` holds, `1` for a
+    /// frame-sized staging buffer.
+    ///
+    /// Both handles are bound whole and the slots addressed by the
+    /// kernel's own offset arguments. Binding a slot directly would
+    /// need its byte offset to be a multiple of the GPU's
+    /// `min_storage_buffer_offset_alignment` (32 bytes), which a frame
+    /// stride only satisfies when `width * height * stored_ch` is a
+    /// multiple of 8.
+    fn copy_frame_into_slot(
+        &self,
+        dst: &Handle,
+        slot: usize,
+        src: &Handle,
+        src_slot: usize,
+        src_slots: usize,
+    ) {
         let stored_ch = self.params.channels.storage_count();
         let frame_size = self.width * self.height * stored_ch;
-        let byte_offset = (slot as u64) * (frame_size as u64) * (size_of::<f32>() as u64);
-        let dst_handle = dst.clone().offset_start(byte_offset);
+        let dst_slots = self.params.total_frames() as usize;
 
         let grid = frame_size.div_ceil(BLOCK_1D).min(MAX_GRID_1D);
         let total_threads = grid * BLOCK_1D;
@@ -989,8 +1004,10 @@ impl<R: Runtime> NlmDenoiser<R> {
                 &self.client,
                 CubeCount::new_1d(grid),
                 CubeDim::new_1d(BLOCK_1D),
-                ArrayArg::from_raw_parts(src.clone(), frame_size as usize),
-                ArrayArg::from_raw_parts(dst_handle.clone(), frame_size as usize),
+                ArrayArg::from_raw_parts(src.clone(), src_slots * frame_size as usize),
+                ArrayArg::from_raw_parts(dst.clone(), dst_slots * frame_size as usize),
+                src_slot as u32 * frame_size,
+                slot as u32 * frame_size,
                 frame_size,
                 total_threads,
             )
@@ -1024,15 +1041,8 @@ impl<R: Runtime> NlmDenoiser<R> {
         let last_slot = (self.ring_head - 1) % total_frames;
         let next_slot = self.ring_head % total_frames;
 
-        let stored_ch = self.params.channels.storage_count();
-        let frame_size = self.width * self.height * stored_ch;
-        let bytes_per_slot = (frame_size as u64) * (size_of::<f32>() as u64);
-
-        let input_src = self
-            .input_buf
-            .clone()
-            .offset_start((last_slot as u64) * bytes_per_slot);
-        self.copy_frame_into_slot(&self.input_buf.clone(), &input_src, next_slot);
+        let input_buf = self.input_buf.clone();
+        self.copy_frame_into_slot(&input_buf, next_slot, &input_buf, last_slot, total_frames);
 
         // Skipped for `NlmSpatial`: the pilot dispatch below recomputes
         // this slot's reference from scratch, so the byte copy would
@@ -1040,10 +1050,7 @@ impl<R: Runtime> NlmDenoiser<R> {
         if !matches!(self.params.prefilter, PrefilterMode::NlmSpatial { .. })
             && let Some(reference_buf) = self.reference_buf.clone()
         {
-            let ref_src = reference_buf
-                .clone()
-                .offset_start((last_slot as u64) * bytes_per_slot);
-            self.copy_frame_into_slot(&reference_buf, &ref_src, next_slot);
+            self.copy_frame_into_slot(&reference_buf, next_slot, &reference_buf, last_slot, total_frames);
         }
 
         // Keep the motion-estimation pyramid and noise estimate for the

--- a/src/nlmeans/dispatch.rs
+++ b/src/nlmeans/dispatch.rs
@@ -189,8 +189,9 @@ impl<R: Runtime> NlmDenoiser<R> {
 
     /// The whole reference ring, for a kernel that addresses one of its
     /// slots itself. Binding a single slot instead would need the
-    /// slot's byte offset to be 32-byte aligned, which a
-    /// `width * height * stored_ch` frame stride does not guarantee.
+    /// slot's byte offset to land on one of the runtime's alignment
+    /// boundaries, which a `width * height * stored_ch` frame stride
+    /// does not guarantee.
     fn reference_ring_arg(&self, ctx: &LaunchCtx) -> ArrayArg<R> {
         let buf = self
             .reference_buf

--- a/src/nlmeans/dispatch.rs
+++ b/src/nlmeans/dispatch.rs
@@ -187,17 +187,16 @@ impl<R: Runtime> NlmDenoiser<R> {
         unsafe { ArrayArg::from_raw_parts(self.outputs[slot].clone(), ctx.frame_size) }
     }
 
-    /// Reference ring slot `slot`, viewed as a single frame-sized array
-    /// via a byte offset into `reference_buf`. Same byte-offset slicing
-    /// pattern as the motion pyramid's per-slot views.
-    fn reference_slot_arg(&self, ctx: &LaunchCtx, slot: u32) -> ArrayArg<R> {
+    /// The whole reference ring, for a kernel that addresses one of its
+    /// slots itself. Binding a single slot instead would need the
+    /// slot's byte offset to be 32-byte aligned, which a
+    /// `width * height * stored_ch` frame stride does not guarantee.
+    fn reference_ring_arg(&self, ctx: &LaunchCtx) -> ArrayArg<R> {
         let buf = self
             .reference_buf
             .as_ref()
             .expect("reference buffer must exist for the nlm spatial pilot");
-        let byte_offset = (slot as u64) * (ctx.frame_size as u64) * (size_of::<f32>() as u64);
-        let handle = buf.clone().offset_start(byte_offset);
-        unsafe { ArrayArg::from_raw_parts(handle, ctx.frame_size) }
+        unsafe { ArrayArg::from_raw_parts(buf.clone(), ctx.total_frame_data) }
     }
 
     fn weight_sum_arg(&self, ctx: &LaunchCtx) -> ArrayArg<R> {
@@ -702,6 +701,7 @@ impl<R: Runtime> NlmDenoiser<R> {
             &self.input_buf,
             compensated_input,
             centre_slot as usize,
+            self.params.total_frames(),
             self.width,
             self.height,
             stored_ch,
@@ -715,6 +715,7 @@ impl<R: Runtime> NlmDenoiser<R> {
                 ref_src,
                 ref_dst,
                 centre_slot as usize,
+                self.params.total_frames(),
                 self.width,
                 self.height,
                 stored_ch,
@@ -922,6 +923,7 @@ impl<R: Runtime> NlmDenoiser<R> {
         &self,
         ctx: &LaunchCtx,
         center_frame: u32,
+        output_frame: u32,
         output: ArrayArg<R>,
     ) -> Result<(), anyhow::Error> {
         let channels = self.params.channels.count();
@@ -937,6 +939,7 @@ impl<R: Runtime> NlmDenoiser<R> {
                 self.weight_sum_arg(ctx),
                 self.max_weight_arg(ctx),
                 center_frame,
+                output_frame,
                 self.params.self_weight,
                 self.width,
                 self.height,
@@ -951,6 +954,7 @@ impl<R: Runtime> NlmDenoiser<R> {
         self.run_finish_to(
             ctx,
             self.phys_frame(center_t as i32),
+            0,
             self.output_arg(ctx, output_slot),
         )
     }
@@ -1025,7 +1029,7 @@ impl<R: Runtime> NlmDenoiser<R> {
             );
         }
 
-        self.run_finish_to(&ctx, slot, self.reference_slot_arg(&ctx, slot))
+        self.run_finish_to(&ctx, slot, slot, self.reference_ring_arg(&ctx))
     }
 
     pub(super) fn run_denoise_kernels(&mut self, output_slot: usize) -> Result<(), anyhow::Error> {
@@ -1095,23 +1099,28 @@ impl<R: Runtime> NlmDenoiser<R> {
 
 /// GPU→GPU copy of one frame from `src`'s slot `slot` into `dst`'s
 /// slot `slot`. Both buffers must share the same ring-buffer layout
-/// (`total_frames * height * width * stored_ch`). Free function so
+/// (`frame_count * height * width * stored_ch`). Free function so
 /// the motion-compensation dispatcher can call it without tying back
 /// into the `NlmDenoiser` impl block (avoids borrow conflicts inside
 /// the per-submit method).
+///
+/// Binds both rings whole and lets the kernel address the slot, for
+/// the alignment reason [`NlmDenoiser::copy_frame_into_slot`]
+/// documents.
+#[allow(clippy::too_many_arguments)]
 fn copy_frame_into_slot_handle<R: Runtime>(
     client: &ComputeClient<R>,
     src: &Handle,
     dst: &Handle,
     slot: usize,
+    frame_count: u32,
     width: u32,
     height: u32,
     stored_ch: u32,
 ) {
     let frame_size = width * height * stored_ch;
-    let byte_offset = (slot as u64) * (frame_size as u64) * (size_of::<f32>() as u64);
-    let src_handle = src.clone().offset_start(byte_offset);
-    let dst_handle = dst.clone().offset_start(byte_offset);
+    let ring_len = frame_count as usize * frame_size as usize;
+    let offset = slot as u32 * frame_size;
 
     let grid = frame_size.div_ceil(BLOCK_1D).min(MAX_GRID_1D);
     let total_threads = grid * BLOCK_1D;
@@ -1121,8 +1130,10 @@ fn copy_frame_into_slot_handle<R: Runtime>(
             client,
             CubeCount::new_1d(grid),
             CubeDim::new_1d(BLOCK_1D),
-            ArrayArg::from_raw_parts(src_handle, frame_size as usize),
-            ArrayArg::from_raw_parts(dst_handle, frame_size as usize),
+            ArrayArg::from_raw_parts(src.clone(), ring_len),
+            ArrayArg::from_raw_parts(dst.clone(), ring_len),
+            offset,
+            offset,
             frame_size,
             total_threads,
         );

--- a/src/nlmeans/kernels/accumulate.rs
+++ b/src/nlmeans/kernels/accumulate.rs
@@ -49,8 +49,8 @@ pub fn nlm_accumulate<N: Size>(
 /// Reads the centre pixel from `input`'s frame `center_frame` and
 /// writes to `output`'s frame `output_frame`, so a caller writing into
 /// a ring buffer slot passes the whole ring rather than binding it at
-/// the slot's byte offset (which the GPU only accepts on 32-byte
-/// boundaries).
+/// the slot's byte offset (which the GPU only accepts on its own
+/// alignment boundaries).
 #[cube(launch_unchecked)]
 pub fn nlm_finish<N: Size>(
     input: &Array<Vector<f32, N>>,

--- a/src/nlmeans/kernels/accumulate.rs
+++ b/src/nlmeans/kernels/accumulate.rs
@@ -45,6 +45,12 @@ pub fn nlm_accumulate<N: Size>(
 ///     `out = (original × m + acc) / (m + weight_sum)`  where  `m = wref × max_weight`.
 /// When the denominator is near zero (no usable matches across the
 /// search window) the original pixel value is preserved unchanged.
+///
+/// Reads the centre pixel from `input`'s frame `center_frame` and
+/// writes to `output`'s frame `output_frame`, so a caller writing into
+/// a ring buffer slot passes the whole ring rather than binding it at
+/// the slot's byte offset (which the GPU only accepts on 32-byte
+/// boundaries).
 #[cube(launch_unchecked)]
 pub fn nlm_finish<N: Size>(
     input: &Array<Vector<f32, N>>,
@@ -53,6 +59,7 @@ pub fn nlm_finish<N: Size>(
     weight_sum: &Array<f32>,
     max_weight: &Array<f32>,
     center_frame: u32,
+    output_frame: u32,
     wref: f32,
     #[comptime] width: u32,
     #[comptime] height: u32,
@@ -66,6 +73,7 @@ pub fn nlm_finish<N: Size>(
 
     let pixel_idx = (y * width + x) as usize;
     let frame_idx = ((center_frame * height + y) * width + x) as usize;
+    let output_idx = ((output_frame * height + y) * width + x) as usize;
 
     let m = wref * max_weight[pixel_idx];
     let denominator = m + weight_sum[pixel_idx];
@@ -90,5 +98,5 @@ pub fn nlm_finish<N: Size>(
         }
     }
 
-    output[pixel_idx] = out;
+    output[output_idx] = out;
 }

--- a/src/nlmeans/kernels/memory.rs
+++ b/src/nlmeans/kernels/memory.rs
@@ -7,9 +7,8 @@ use cubecl::prelude::*;
 /// The offsets are kernel arguments rather than byte offsets on the
 /// bound handles, so a caller can address one slot of a ring buffer
 /// whatever its stride. The GPU only accepts a buffer bound at a
-/// multiple of its `min_storage_buffer_offset_alignment` (32 bytes),
-/// which a `width * height * stored_ch` frame stride only meets when
-/// that product happens to be a multiple of 8.
+/// multiple of its `min_storage_buffer_offset_alignment`, which a
+/// `width * height * stored_ch` frame stride meets only by luck.
 #[cube(launch_unchecked)]
 pub fn gpu_copy(
     src: &Array<f32>,

--- a/src/nlmeans/kernels/memory.rs
+++ b/src/nlmeans/kernels/memory.rs
@@ -1,17 +1,27 @@
 use cubecl::prelude::*;
 
-/// GPU→GPU buffer copy. Uses a strided loop so the grid can be capped
-/// under the 65 535 1D dispatch limit.
+/// GPU→GPU buffer copy of `length` elements from `src[src_offset..]`
+/// into `dst[dst_offset..]`. Uses a strided loop so the grid can be
+/// capped under the 65 535 1D dispatch limit.
+///
+/// The offsets are kernel arguments rather than byte offsets on the
+/// bound handles, so a caller can address one slot of a ring buffer
+/// whatever its stride. The GPU only accepts a buffer bound at a
+/// multiple of its `min_storage_buffer_offset_alignment` (32 bytes),
+/// which a `width * height * stored_ch` frame stride only meets when
+/// that product happens to be a multiple of 8.
 #[cube(launch_unchecked)]
 pub fn gpu_copy(
     src: &Array<f32>,
     dst: &mut Array<f32>,
+    src_offset: u32,
+    dst_offset: u32,
     #[comptime] length: u32,
     #[comptime] total_threads: u32,
 ) {
     let mut idx = ABSOLUTE_POS_X;
     while idx < length {
-        dst[idx as usize] = src[idx as usize];
+        dst[(dst_offset + idx) as usize] = src[(src_offset + idx) as usize];
         idx += total_threads;
     }
 }

--- a/src/nlmeans/mod.rs
+++ b/src/nlmeans/mod.rs
@@ -2,6 +2,7 @@ pub mod kernels;
 pub mod motion;
 pub mod prefilter;
 
+mod align;
 mod denoiser;
 mod dispatch;
 mod noise;

--- a/src/nlmeans/motion/analyse.rs
+++ b/src/nlmeans/motion/analyse.rs
@@ -3,6 +3,8 @@ use cubecl::server::Handle;
 
 use super::MotionCtx;
 use super::pyramid::{level_dims, pyramid_slot_byte_offset};
+#[cfg(test)]
+use crate::nlmeans::align::StorageAlign;
 use crate::nlmeans::kernels::motion::{nlm_mc_block_match_coarse, nlm_mc_block_match_fine};
 
 /// Byte offset of the MV-field slice for a given neighbour index.
@@ -81,6 +83,7 @@ pub(crate) fn run_analyse<R: Runtime>(
             frame_count,
             coarse_level,
             centre_slot,
+            mc.align,
         ));
         let coarse_neighbour = pyramid.clone().offset_start(pyramid_slot_byte_offset(
             width,
@@ -88,6 +91,7 @@ pub(crate) fn run_analyse<R: Runtime>(
             frame_count,
             coarse_level,
             neighbour_slot,
+            mc.align,
         ));
         let level_len = (cw * ch) as usize;
         let coarse_scale = 1u32 << coarse_level;
@@ -136,6 +140,7 @@ pub(crate) fn run_analyse<R: Runtime>(
         frame_count,
         0,
         centre_slot,
+        mc.align,
     ));
     let fine_neighbour = pyramid.clone().offset_start(pyramid_slot_byte_offset(
         width,
@@ -143,6 +148,7 @@ pub(crate) fn run_analyse<R: Runtime>(
         frame_count,
         0,
         neighbour_slot,
+        mc.align,
     ));
     let level_len = (fw * fh) as usize;
     let grid = CubeCount::new_2d(mc.blocks_x, mc.blocks_y);
@@ -225,6 +231,7 @@ pub(crate) fn run_seeded_refine<R: Runtime>(
         frame_count,
         0,
         centre_slot,
+        mc.align,
     ));
     let fine_neighbour = pyramid.clone().offset_start(pyramid_slot_byte_offset(
         width,
@@ -232,6 +239,7 @@ pub(crate) fn run_seeded_refine<R: Runtime>(
         frame_count,
         0,
         neighbour_slot,
+        mc.align,
     ));
     let level_len = (fw * fh) as usize;
     let grid = CubeCount::new_2d(mc.blocks_x, mc.blocks_y);
@@ -268,6 +276,11 @@ mod tests {
     use super::*;
     use crate::nlmeans::motion::{MotionCompensationMode, MotionEstimation};
 
+    /// The alignment the Vulkan adapters we test against report.
+    fn align() -> StorageAlign {
+        StorageAlign::new(32)
+    }
+
     fn mc(blksize: u32, overlap: u32) -> MotionCtx {
         MotionCtx::new(
             MotionCompensationMode::Mvtools {
@@ -279,6 +292,7 @@ mod tests {
             },
             64,
             64,
+            align(),
         )
         .unwrap()
     }
@@ -337,6 +351,7 @@ mod tests {
             },
             4,
             4,
+            align(),
         )
         .unwrap();
         assert_eq!(
@@ -365,6 +380,7 @@ mod tests {
             },
             4,
             4,
+            align(),
         )
         .unwrap();
         assert_eq!(
@@ -387,7 +403,7 @@ mod tests {
         // misaligned. 1920x1080 (the harness's usual frame size)
         // happens to land on an even block count at this geometry, so
         // it never exercises this rounding.
-        let m = MotionCtx::new(MotionCompensationMode::mvtools_default(), 1080, 1080).unwrap();
+        let m = MotionCtx::new(MotionCompensationMode::mvtools_default(), 1080, 1080, align()).unwrap();
         assert_eq!(
             m.blocks_x * m.blocks_y,
             18225,

--- a/src/nlmeans/motion/chain.rs
+++ b/src/nlmeans/motion/chain.rs
@@ -264,6 +264,7 @@ impl<R: Runtime> NlmDenoiser<R> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::nlmeans::align::StorageAlign;
     use crate::nlmeans::motion::{MotionCompensationMode, MotionEstimation};
 
     #[test]
@@ -292,6 +293,7 @@ mod tests {
             },
             4,
             4,
+            StorageAlign::new(32),
         )
         .unwrap();
         assert_eq!(
@@ -325,6 +327,7 @@ mod tests {
             },
             8,
             4,
+            StorageAlign::new(32),
         )
         .unwrap();
         assert_eq!(

--- a/src/nlmeans/motion/confidence.rs
+++ b/src/nlmeans/motion/confidence.rs
@@ -61,6 +61,7 @@ pub(crate) fn run_confidence_for_neighbour<R: Runtime>(
         frame_count,
         0,
         centre_slot,
+        ctx.align,
     ));
     let neighbour = luma_pyramid.clone().offset_start(pyramid_slot_byte_offset(
         width,
@@ -68,6 +69,7 @@ pub(crate) fn run_confidence_for_neighbour<R: Runtime>(
         frame_count,
         0,
         neighbour_slot,
+        ctx.align,
     ));
     let level_len = (fw * fh) as usize;
 

--- a/src/nlmeans/motion/mod.rs
+++ b/src/nlmeans/motion/mod.rs
@@ -16,6 +16,8 @@ use cubecl::prelude::*;
 use cubecl::server::Handle;
 pub(crate) use pyramid::{pyramid_pixels_per_frame, run_pyramid_build};
 
+use crate::nlmeans::align::StorageAlign;
+
 /// How motion compensation is configured for a denoise pass.
 ///
 /// `None` disables motion compensation entirely (zero-cost; no extra
@@ -246,10 +248,14 @@ pub(crate) struct MotionCtx {
     pub pyramid_levels: u32,
     pub blocks_x: u32,
     pub blocks_y: u32,
+    /// Alignment every buffer this context slices per-slot must respect
+    /// (the MV field, the confidence buffer, the pair ring, and the
+    /// pyramid). Read from the runtime, see [`StorageAlign`].
+    pub align: StorageAlign,
 }
 
 impl MotionCtx {
-    pub fn new(mode: MotionCompensationMode, width: u32, height: u32) -> Option<Self> {
+    pub fn new(mode: MotionCompensationMode, width: u32, height: u32, align: StorageAlign) -> Option<Self> {
         let MotionCompensationMode::Mvtools {
             blksize,
             overlap,
@@ -272,6 +278,7 @@ impl MotionCtx {
             pyramid_levels,
             blocks_x,
             blocks_y,
+            align,
         })
     }
 
@@ -281,25 +288,25 @@ impl MotionCtx {
     }
 
     /// Padded per-neighbour MV-field stride in bytes. Two `i32`
-    /// components (`dx`, `dy`) per block, rounded up to the GPU
-    /// storage-buffer offset alignment (32 bytes), the same convention
+    /// components (`dx`, `dy`) per block, rounded up to the runtime's
+    /// buffer-binding alignment, the same convention
     /// [`Self::confidence_bytes_per_neighbour`] uses. `wgpu` rejects a
     /// bind-group offset that isn't a multiple of its
     /// `min_storage_buffer_offset_alignment`, and an odd block count
-    /// leaves the unpadded 8-byte-per-block stride short of a 32-byte
-    /// multiple.
+    /// leaves the unpadded 8-byte-per-block stride short of that
+    /// boundary.
     pub(crate) fn mv_field_bytes_per_neighbour(&self) -> u64 {
         let blocks = (self.blocks_x as u64) * (self.blocks_y as u64);
-        (blocks * 2 * size_of::<i32>() as u64).next_multiple_of(32)
+        self.align.pad_bytes(blocks * 2 * size_of::<i32>() as u64)
     }
 
     /// Padded per-neighbour confidence-buffer stride in bytes. One
-    /// `f32` per block, rounded up to the GPU storage-buffer offset
-    /// alignment (32 bytes), the same convention
+    /// `f32` per block, rounded up to the runtime's buffer-binding
+    /// alignment, the same convention
     /// [`Self::mv_field_bytes_per_neighbour`] uses for the MV field.
     pub(crate) fn confidence_bytes_per_neighbour(&self) -> u64 {
         let blocks = (self.blocks_x as u64) * (self.blocks_y as u64);
-        (blocks * size_of::<f32>() as u64).next_multiple_of(32)
+        self.align.pad_bytes(blocks * size_of::<f32>() as u64)
     }
 
     /// i32 elements per pair-ring direction sub-array, one `(dx, dy)`
@@ -312,14 +319,15 @@ impl MotionCtx {
     }
 
     /// Padded per-direction pair-ring stride in bytes, rounded up to
-    /// the GPU storage-buffer offset alignment (32 bytes), the same
-    /// convention [`Self::confidence_bytes_per_neighbour`] uses. Both
+    /// the runtime's buffer-binding alignment, the same convention
+    /// [`Self::confidence_bytes_per_neighbour`] uses. Both
     /// `pair_byte_offset` (the host-side write and zero-fill offset)
     /// and the chain-compose kernel's own internal read stride use
     /// this padded value, so a direction's data starts at the same
     /// place for every reader and writer.
     pub(crate) fn pair_direction_bytes(&self) -> u64 {
-        (self.pair_direction_len() as u64 * size_of::<i32>() as u64).next_multiple_of(32)
+        self.align
+            .pad_bytes(self.pair_direction_len() as u64 * size_of::<i32>() as u64)
     }
 
     /// Padded per-slot pair-ring stride in bytes, both directions back
@@ -348,7 +356,7 @@ impl MotionCtx {
     /// per-block SAD, no motion search). Used when confidence
     /// weighting is active but no `Mvtools` mode was configured to
     /// derive geometry from.
-    pub(crate) fn confidence_only(width: u32, height: u32) -> Self {
+    pub(crate) fn confidence_only(width: u32, height: u32, align: StorageAlign) -> Self {
         Self::new(
             MotionCompensationMode::Mvtools {
                 blksize: DEFAULT_BLKSIZE,
@@ -359,6 +367,7 @@ impl MotionCtx {
             },
             width,
             height,
+            align,
         )
         .expect("Mvtools variant always yields Some")
     }
@@ -649,7 +658,7 @@ mod tests {
             pyramid_levels: 2,
             estimation: MotionEstimation::Direct,
         };
-        let ctx = MotionCtx::new(mode, 1920, 1080).unwrap();
+        let ctx = MotionCtx::new(mode, 1920, 1080, StorageAlign::new(32)).unwrap();
         assert_eq!(ctx.step, 8);
         assert_eq!(ctx.blocks_x, 1920u32.div_ceil(8));
         assert_eq!(ctx.blocks_y, 1080u32.div_ceil(8));

--- a/src/nlmeans/motion/pyramid.rs
+++ b/src/nlmeans/motion/pyramid.rs
@@ -4,35 +4,45 @@ use cubecl::server::Handle;
 use super::MotionCtx;
 use crate::nlmeans::kernels::motion::{nlm_mc_downscale, nlm_mc_extract_luma};
 
+/// GPU storage-buffer offset alignment expressed in `f32` elements
+/// (32 bytes). Every pyramid slot starts on a multiple of this, the
+/// same 32-byte convention [`MotionCtx::mv_field_bytes_per_neighbour`]
+/// pads the MV field to.
+const SLOT_ALIGN_PIXELS: usize = 32 / size_of::<f32>();
+
+/// Luma pixels one frame occupies at `level`, padded up to
+/// [`SLOT_ALIGN_PIXELS`]. Slot offsets are sums of whole slot strides,
+/// so padding the stride is what keeps every offset 32-byte aligned.
+/// `wgpu` rejects a bind-group offset that isn't a multiple of its
+/// `min_storage_buffer_offset_alignment`, and a level whose `w * h`
+/// isn't a multiple of 8 (a 180x137 chroma level, say) leaves every
+/// odd slot short of that boundary. Kernels only ever read a slot's
+/// leading `w * h` pixels, so the pad is never touched.
+fn level_slot_pixels(width: u32, height: u32, level: u32) -> usize {
+    let (w, h) = level_dims(width, height, level);
+    ((w as usize) * (h as usize)).next_multiple_of(SLOT_ALIGN_PIXELS)
+}
+
 /// Number of luma pixels stored per frame across every pyramid level
 /// for an image of `(width, height)`. Level 0 contributes `w*h`; each
-/// subsequent level halves both axes.
+/// subsequent level halves both axes. Each level's contribution is
+/// padded to [`SLOT_ALIGN_PIXELS`], matching the layout
+/// [`pyramid_slot_byte_offset`] addresses.
 pub fn pyramid_pixels_per_frame(width: u32, height: u32, levels: u32) -> usize {
-    let mut total: usize = 0;
-    let mut w = width;
-    let mut h = height;
-    for _ in 0..levels {
-        total += (w as usize) * (h as usize);
-        w = (w / 2).max(1);
-        h = (h / 2).max(1);
-    }
-    total
+    (0..levels)
+        .map(|level| level_slot_pixels(width, height, level))
+        .sum()
 }
 
 /// Byte offset of a given `(level, frame)` slot inside the flat pyramid
-/// buffer.
+/// buffer. Always a multiple of 32, see [`level_slot_pixels`].
 pub fn pyramid_slot_byte_offset(width: u32, height: u32, frame_count: u32, level: u32, frame: u32) -> u64 {
-    let mut offset_pixels: u64 = 0;
-    let mut w = width as u64;
-    let mut h = height as u64;
+    let mut offset_pixels: usize = 0;
     for l in 0..level {
-        offset_pixels += (frame_count as u64) * w * h;
-        w = (w / 2).max(1);
-        h = (h / 2).max(1);
-        let _ = l;
+        offset_pixels += (frame_count as usize) * level_slot_pixels(width, height, l);
     }
-    offset_pixels += (frame as u64) * w * h;
-    offset_pixels * (size_of::<f32>() as u64)
+    offset_pixels += (frame as usize) * level_slot_pixels(width, height, level);
+    (offset_pixels * size_of::<f32>()) as u64
 }
 
 /// Pixel dimensions at `level` (level 0 = full res).
@@ -183,6 +193,48 @@ mod tests {
         assert_eq!(level_dims(64, 32, 0), (64, 32));
         assert_eq!(level_dims(64, 32, 1), (32, 16));
         assert_eq!(level_dims(64, 32, 2), (16, 8));
+    }
+
+    #[test]
+    fn slot_byte_offsets_are_storage_aligned() {
+        // `wgpu` rejects a bind-group offset that isn't a multiple of
+        // `min_storage_buffer_offset_alignment` (32 bytes). Every
+        // dimension pair here has at least one level whose unpadded
+        // slot stride falls short of that: 360x274 is the chroma plane
+        // of a 720x548 frame, whose /2 level is 180x137 = 24 660 f32 =
+        // 98 640 bytes, 16 bytes short of a 32-byte multiple.
+        for (w, h) in [(360, 274), (720, 548), (722, 546), (66, 66), (42, 28)] {
+            for level in 0..super::super::MAX_PYRAMID_LEVELS {
+                for frame in 0..5 {
+                    let offset = pyramid_slot_byte_offset(w, h, 5, level, frame);
+                    assert_eq!(
+                        offset % 32,
+                        0,
+                        "{w}x{h} level={level} frame={frame} lands at byte {offset}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn pixels_per_frame_covers_the_last_slot_of_every_level() {
+        // The allocation `pyramid_pixels_per_frame` sizes must hold
+        // every slot `pyramid_slot_byte_offset` addresses, padding
+        // included.
+        let (w, h, frames, levels) = (360u32, 274u32, 5u32, 3u32);
+        let total_bytes = pyramid_pixels_per_frame(w, h, levels) * frames as usize * size_of::<f32>();
+
+        for level in 0..levels {
+            let (lw, lh) = level_dims(w, h, level);
+            let last = pyramid_slot_byte_offset(w, h, frames, level, frames - 1) as usize;
+            let end = last + (lw * lh) as usize * size_of::<f32>();
+            assert!(
+                end <= total_bytes,
+                "level {level} slot {} ends at {end}, past the {total_bytes}-byte buffer",
+                frames - 1
+            );
+        }
     }
 
     #[test]

--- a/src/nlmeans/motion/pyramid.rs
+++ b/src/nlmeans/motion/pyramid.rs
@@ -2,46 +2,48 @@ use cubecl::prelude::*;
 use cubecl::server::Handle;
 
 use super::MotionCtx;
+use crate::nlmeans::align::StorageAlign;
 use crate::nlmeans::kernels::motion::{nlm_mc_downscale, nlm_mc_extract_luma};
 
-/// GPU storage-buffer offset alignment expressed in `f32` elements
-/// (32 bytes). Every pyramid slot starts on a multiple of this, the
-/// same 32-byte convention [`MotionCtx::mv_field_bytes_per_neighbour`]
-/// pads the MV field to.
-const SLOT_ALIGN_PIXELS: usize = 32 / size_of::<f32>();
-
-/// Luma pixels one frame occupies at `level`, padded up to
-/// [`SLOT_ALIGN_PIXELS`]. Slot offsets are sums of whole slot strides,
-/// so padding the stride is what keeps every offset 32-byte aligned.
+/// Luma pixels one frame occupies at `level`, padded up to a whole
+/// number of `align` boundaries. Slot offsets are sums of whole slot
+/// strides, so padding the stride is what keeps every offset aligned.
 /// `wgpu` rejects a bind-group offset that isn't a multiple of its
 /// `min_storage_buffer_offset_alignment`, and a level whose `w * h`
-/// isn't a multiple of 8 (a 180x137 chroma level, say) leaves every
-/// odd slot short of that boundary. Kernels only ever read a slot's
+/// doesn't fill whole boundaries (a 180x137 chroma level, say) leaves
+/// every odd slot short of one. Kernels only ever read a slot's
 /// leading `w * h` pixels, so the pad is never touched.
-fn level_slot_pixels(width: u32, height: u32, level: u32) -> usize {
+fn level_slot_pixels(width: u32, height: u32, level: u32, align: StorageAlign) -> usize {
     let (w, h) = level_dims(width, height, level);
-    ((w as usize) * (h as usize)).next_multiple_of(SLOT_ALIGN_PIXELS)
+    align.pad_elems::<f32>((w as usize) * (h as usize))
 }
 
 /// Number of luma pixels stored per frame across every pyramid level
 /// for an image of `(width, height)`. Level 0 contributes `w*h`; each
 /// subsequent level halves both axes. Each level's contribution is
-/// padded to [`SLOT_ALIGN_PIXELS`], matching the layout
+/// padded to `align`, matching the layout
 /// [`pyramid_slot_byte_offset`] addresses.
-pub fn pyramid_pixels_per_frame(width: u32, height: u32, levels: u32) -> usize {
+pub fn pyramid_pixels_per_frame(width: u32, height: u32, levels: u32, align: StorageAlign) -> usize {
     (0..levels)
-        .map(|level| level_slot_pixels(width, height, level))
+        .map(|level| level_slot_pixels(width, height, level, align))
         .sum()
 }
 
 /// Byte offset of a given `(level, frame)` slot inside the flat pyramid
-/// buffer. Always a multiple of 32, see [`level_slot_pixels`].
-pub fn pyramid_slot_byte_offset(width: u32, height: u32, frame_count: u32, level: u32, frame: u32) -> u64 {
+/// buffer. Always a multiple of `align`, see [`level_slot_pixels`].
+pub fn pyramid_slot_byte_offset(
+    width: u32,
+    height: u32,
+    frame_count: u32,
+    level: u32,
+    frame: u32,
+    align: StorageAlign,
+) -> u64 {
     let mut offset_pixels: usize = 0;
     for l in 0..level {
-        offset_pixels += (frame_count as usize) * level_slot_pixels(width, height, l);
+        offset_pixels += (frame_count as usize) * level_slot_pixels(width, height, l, align);
     }
-    offset_pixels += (frame as usize) * level_slot_pixels(width, height, level);
+    offset_pixels += (frame as usize) * level_slot_pixels(width, height, level, align);
     (offset_pixels * size_of::<f32>()) as u64
 }
 
@@ -82,9 +84,10 @@ pub(crate) fn run_pyramid_build<R: Runtime>(
         height,
         frame_count,
         stored_ch,
+        mc.align,
     );
     for level in 1..mc.pyramid_levels {
-        downscale_level::<R>(client, pyramid, slot, width, height, frame_count, level);
+        downscale_level::<R>(client, pyramid, slot, width, height, frame_count, level, mc.align);
     }
     Ok(())
 }
@@ -99,16 +102,21 @@ fn extract_luma<R: Runtime>(
     height: u32,
     frame_count: u32,
     stored_ch: u32,
+    align: StorageAlign,
 ) {
     let block_x = 16u32;
     let block_y = 16u32;
     let grid = CubeCount::new_2d(width.div_ceil(block_x), height.div_ceil(block_y));
     let dim = CubeDim::new_2d(block_x, block_y);
     let full_len = (frame_count * height * width * stored_ch) as usize;
-    let level0_dst =
-        pyramid
-            .clone()
-            .offset_start(pyramid_slot_byte_offset(width, height, frame_count, 0, slot));
+    let level0_dst = pyramid.clone().offset_start(pyramid_slot_byte_offset(
+        width,
+        height,
+        frame_count,
+        0,
+        slot,
+        align,
+    ));
     let level0_len = (frame_count * height * width) as usize;
 
     unsafe {
@@ -127,6 +135,7 @@ fn extract_luma<R: Runtime>(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn downscale_level<R: Runtime>(
     client: &ComputeClient<R>,
     pyramid: &Handle,
@@ -135,6 +144,7 @@ fn downscale_level<R: Runtime>(
     height: u32,
     frame_count: u32,
     level: u32,
+    align: StorageAlign,
 ) {
     let (src_w, src_h) = level_dims(width, height, level - 1);
     let (dst_w, dst_h) = level_dims(width, height, level);
@@ -149,10 +159,16 @@ fn downscale_level<R: Runtime>(
         frame_count,
         level - 1,
         slot,
+        align,
     ));
-    let dst = pyramid
-        .clone()
-        .offset_start(pyramid_slot_byte_offset(width, height, frame_count, level, slot));
+    let dst = pyramid.clone().offset_start(pyramid_slot_byte_offset(
+        width,
+        height,
+        frame_count,
+        level,
+        slot,
+        align,
+    ));
     let src_len = (src_w * src_h) as usize;
     let dst_len = (dst_w * dst_h) as usize;
 
@@ -177,15 +193,20 @@ fn downscale_level<R: Runtime>(
 mod tests {
     use super::*;
 
+    /// The alignment the Vulkan adapters we test against report.
+    fn align() -> StorageAlign {
+        StorageAlign::new(32)
+    }
+
     #[test]
     fn pyramid_pixels_single_level_matches_image() {
-        assert_eq!(pyramid_pixels_per_frame(64, 32, 1), 64 * 32);
+        assert_eq!(pyramid_pixels_per_frame(64, 32, 1, align()), 64 * 32);
     }
 
     #[test]
     fn pyramid_pixels_two_levels_sums_levels() {
         // Level 0: 64x32 = 2048; level 1: 32x16 = 512. Total 2560.
-        assert_eq!(pyramid_pixels_per_frame(64, 32, 2), 2048 + 512);
+        assert_eq!(pyramid_pixels_per_frame(64, 32, 2, align()), 2048 + 512);
     }
 
     #[test]
@@ -196,22 +217,26 @@ mod tests {
     }
 
     #[test]
-    fn slot_byte_offsets_are_storage_aligned() {
-        // `wgpu` rejects a bind-group offset that isn't a multiple of
-        // `min_storage_buffer_offset_alignment` (32 bytes). Every
-        // dimension pair here has at least one level whose unpadded
-        // slot stride falls short of that: 360x274 is the chroma plane
-        // of a 720x548 frame, whose /2 level is 180x137 = 24 660 f32 =
-        // 98 640 bytes, 16 bytes short of a 32-byte multiple.
-        for (w, h) in [(360, 274), (720, 548), (722, 546), (66, 66), (42, 28)] {
-            for level in 0..super::super::MAX_PYRAMID_LEVELS {
-                for frame in 0..5 {
-                    let offset = pyramid_slot_byte_offset(w, h, 5, level, frame);
-                    assert_eq!(
-                        offset % 32,
-                        0,
-                        "{w}x{h} level={level} frame={frame} lands at byte {offset}"
-                    );
+    fn slot_byte_offsets_respect_every_alignment_a_runtime_can_report() {
+        // A GPU rejects a bind-group offset that isn't a multiple of
+        // `min_storage_buffer_offset_alignment`, which backends report
+        // anywhere from 4 to 256 bytes. Every dimension pair here has
+        // at least one level whose unpadded slot stride falls short:
+        // 360x274 is the chroma plane of a 720x548 frame, whose /2
+        // level is 180x137 = 24 660 f32 = 98 640 bytes, 16 bytes short
+        // of a 32-byte boundary.
+        for bytes in [4u64, 16, 32, 64, 256] {
+            let align = StorageAlign::new(bytes);
+            for (w, h) in [(360, 274), (720, 548), (722, 546), (66, 66), (42, 28)] {
+                for level in 0..super::super::MAX_PYRAMID_LEVELS {
+                    for frame in 0..5 {
+                        let offset = pyramid_slot_byte_offset(w, h, 5, level, frame, align);
+                        assert_eq!(
+                            offset % bytes,
+                            0,
+                            "align {bytes}: {w}x{h} level={level} frame={frame} lands at byte {offset}"
+                        );
+                    }
                 }
             }
         }
@@ -221,19 +246,24 @@ mod tests {
     fn pixels_per_frame_covers_the_last_slot_of_every_level() {
         // The allocation `pyramid_pixels_per_frame` sizes must hold
         // every slot `pyramid_slot_byte_offset` addresses, padding
-        // included.
+        // included, whatever the runtime's alignment.
         let (w, h, frames, levels) = (360u32, 274u32, 5u32, 3u32);
-        let total_bytes = pyramid_pixels_per_frame(w, h, levels) * frames as usize * size_of::<f32>();
 
-        for level in 0..levels {
-            let (lw, lh) = level_dims(w, h, level);
-            let last = pyramid_slot_byte_offset(w, h, frames, level, frames - 1) as usize;
-            let end = last + (lw * lh) as usize * size_of::<f32>();
-            assert!(
-                end <= total_bytes,
-                "level {level} slot {} ends at {end}, past the {total_bytes}-byte buffer",
-                frames - 1
-            );
+        for bytes in [4u64, 16, 32, 64, 256] {
+            let align = StorageAlign::new(bytes);
+            let total_bytes =
+                pyramid_pixels_per_frame(w, h, levels, align) * frames as usize * size_of::<f32>();
+
+            for level in 0..levels {
+                let (lw, lh) = level_dims(w, h, level);
+                let last = pyramid_slot_byte_offset(w, h, frames, level, frames - 1, align) as usize;
+                let end = last + (lw * lh) as usize * size_of::<f32>();
+                assert!(
+                    end <= total_bytes,
+                    "align {bytes}: level {level} slot {} ends at {end}, past the {total_bytes}-byte buffer",
+                    frames - 1
+                );
+            }
         }
     }
 
@@ -242,7 +272,7 @@ mod tests {
         // 4 frames, 64x32 image, 2 levels. Offset to (level=1, frame=2):
         //   skip level 0 entirely: 4 * 64 * 32 = 8192 pixels
         //   plus 2 frames at level 1 (32x16 = 512 each): 1024 pixels
-        let bytes = pyramid_slot_byte_offset(64, 32, 4, 1, 2);
+        let bytes = pyramid_slot_byte_offset(64, 32, 4, 1, 2, align());
         assert_eq!(bytes as usize, (8192 + 1024) * 4);
     }
 }

--- a/src/nlmeans/noise/mod.rs
+++ b/src/nlmeans/noise/mod.rs
@@ -1,6 +1,7 @@
 use cubecl::prelude::*;
 use cubecl::server::Handle;
 
+use super::align::StorageAlign;
 use super::kernels::{
     nlm_noise_partial,
     nlm_noise_reduce,
@@ -33,14 +34,13 @@ pub(super) fn partials_len(width: u32, height: u32) -> usize {
 }
 
 /// Byte stride between ring slots in the stage-1 partials buffer,
-/// padded up to the GPU storage-buffer offset alignment (32 bytes).
-/// Small frames can produce a [`partials_len`] under 8 `f32`s, and
-/// `wgpu` rejects a bind-group offset that isn't a multiple of its
+/// padded up to the runtime's buffer-binding alignment. Small frames
+/// can produce a [`partials_len`] short of one boundary, and `wgpu`
+/// rejects a bind-group offset that isn't a multiple of its
 /// `min_storage_buffer_offset_alignment` — mirrors
 /// [`temporal_stats_slot_stride_bytes`].
-pub(super) fn noise_partials_slot_stride_bytes(width: u32, height: u32) -> u64 {
-    let bytes = partials_len(width, height) as u64 * size_of::<f32>() as u64;
-    bytes.next_multiple_of(32)
+pub(super) fn noise_partials_slot_stride_bytes(width: u32, height: u32, align: StorageAlign) -> u64 {
+    align.pad_bytes(partials_len(width, height) as u64 * size_of::<f32>() as u64)
 }
 
 /// Dispatch both stages of the Immerkær noise estimate for `ctx.frame`,
@@ -187,20 +187,29 @@ pub(super) fn temporal_stats_slot_len(width: u32, height: u32, stored_ch: u32) -
 }
 
 /// Byte stride between ring slots in the temporal-stats buffer, padded
-/// up to the GPU storage-buffer offset alignment (32 bytes). Small
-/// frames (or a single-channel mode) can produce a
-/// [`temporal_stats_slot_len`] under 8 `f32`s, and `wgpu` rejects a
-/// bind-group offset that isn't a multiple of its
-/// `min_storage_buffer_offset_alignment` — mirrors
-/// `MotionCtx::confidence_bytes_per_neighbour`.
-pub(super) fn temporal_stats_slot_stride_bytes(width: u32, height: u32, stored_ch: u32) -> u64 {
-    let bytes = temporal_stats_slot_len(width, height, stored_ch) as u64 * size_of::<f32>() as u64;
-    bytes.next_multiple_of(32)
+/// up to the runtime's buffer-binding alignment. Small frames (or a
+/// single-channel mode) can produce a [`temporal_stats_slot_len`]
+/// short of one boundary, and `wgpu` rejects a bind-group offset that
+/// isn't a multiple of its `min_storage_buffer_offset_alignment` —
+/// mirrors `MotionCtx::confidence_bytes_per_neighbour`.
+pub(super) fn temporal_stats_slot_stride_bytes(
+    width: u32,
+    height: u32,
+    stored_ch: u32,
+    align: StorageAlign,
+) -> u64 {
+    align.pad_bytes(temporal_stats_slot_len(width, height, stored_ch) as u64 * size_of::<f32>() as u64)
 }
 
 /// Total byte size of a `frame_count`-slot temporal-stats ring.
-pub(super) fn temporal_stats_buf_bytes(width: u32, height: u32, stored_ch: u32, frame_count: u32) -> usize {
-    (temporal_stats_slot_stride_bytes(width, height, stored_ch) * frame_count as u64) as usize
+pub(super) fn temporal_stats_buf_bytes(
+    width: u32,
+    height: u32,
+    stored_ch: u32,
+    frame_count: u32,
+    align: StorageAlign,
+) -> usize {
+    (temporal_stats_slot_stride_bytes(width, height, stored_ch, align) * frame_count as u64) as usize
 }
 
 /// Inputs for a single temporal-residual noise-stats dispatch, diffing
@@ -214,6 +223,7 @@ pub(super) struct TemporalStatsCtx<'a> {
     pub slot_prev: u32,
     pub input_buf: &'a Handle,
     pub stats_buf: &'a Handle,
+    pub align: StorageAlign,
 }
 
 /// Dispatch the temporal residual stats kernel for `ctx.slot_new`,
@@ -229,7 +239,7 @@ pub(super) fn run_temporal_noise_stats<R: Runtime>(
     let total_input = (ctx.frame_count * ctx.height * ctx.width * ctx.stored_ch) as usize;
     let (blocks_x, blocks_y) = temporal_stats_blocks(ctx.width, ctx.height);
     let slot_len = temporal_stats_slot_len(ctx.width, ctx.height, ctx.stored_ch);
-    let stride = temporal_stats_slot_stride_bytes(ctx.width, ctx.height, ctx.stored_ch);
+    let stride = temporal_stats_slot_stride_bytes(ctx.width, ctx.height, ctx.stored_ch, ctx.align);
     let stats_slot = ctx.stats_buf.clone().offset_start((ctx.slot_new as u64) * stride);
 
     unsafe {
@@ -264,9 +274,10 @@ pub(super) fn zero_temporal_stats_slot<R: Runtime>(
     height: u32,
     stored_ch: u32,
     slot: u32,
+    align: StorageAlign,
 ) {
     let slot_len = temporal_stats_slot_len(width, height, stored_ch) as u32;
-    let stride = temporal_stats_slot_stride_bytes(width, height, stored_ch);
+    let stride = temporal_stats_slot_stride_bytes(width, height, stored_ch, align);
     let dst = stats_buf.clone().offset_start((slot as u64) * stride);
 
     let grid = slot_len.div_ceil(BLOCK_1D).min(MAX_GRID_1D);
@@ -287,6 +298,7 @@ pub(super) fn zero_temporal_stats_slot<R: Runtime>(
 /// Reads back exactly one ring slot's temporal-stats region as owned
 /// `f32`s. Slices the shared ring handle by byte offset so the
 /// transfer is proportional to one slot instead of the whole ring.
+#[allow(clippy::too_many_arguments)]
 pub(super) fn read_temporal_stats_slot<R: Runtime>(
     client: &ComputeClient<R>,
     stats_buf: &Handle,
@@ -295,9 +307,10 @@ pub(super) fn read_temporal_stats_slot<R: Runtime>(
     stored_ch: u32,
     frame_count: u32,
     slot: u32,
+    align: StorageAlign,
 ) -> Result<Vec<f32>, anyhow::Error> {
     let slot_len_bytes = temporal_stats_slot_len(width, height, stored_ch) as u64 * size_of::<f32>() as u64;
-    let stride = temporal_stats_slot_stride_bytes(width, height, stored_ch);
+    let stride = temporal_stats_slot_stride_bytes(width, height, stored_ch, align);
     let total_bytes = frame_count as u64 * stride;
     let start = (slot as u64) * stride;
     let end_trim = total_bytes - start - slot_len_bytes;
@@ -821,14 +834,14 @@ mod tests {
     fn noise_partials_slot_stride_bytes_pads_odd_cube_count() {
         // A single BLOCK_X x BLOCK_Y cube, partials_len(32, 8) = 4
         // f32s = 16 bytes, padded up to the next 32-byte multiple.
-        assert_eq!(noise_partials_slot_stride_bytes(32, 8), 32);
+        assert_eq!(noise_partials_slot_stride_bytes(32, 8, StorageAlign::new(32)), 32);
     }
 
     #[test]
     fn noise_partials_slot_stride_bytes_aligned_count_unchanged() {
         // A 2x2 cube grid, partials_len(33, 9) = 16 f32s = 64 bytes,
         // already a multiple of 32, so no padding is added.
-        assert_eq!(noise_partials_slot_stride_bytes(33, 9), 64);
+        assert_eq!(noise_partials_slot_stride_bytes(33, 9, StorageAlign::new(32)), 64);
     }
 
     /// A `70x20` frame grids into a ragged 3x3 cube layout (`BLOCK_X =

--- a/src/nlmeans/tests/alignment.rs
+++ b/src/nlmeans/tests/alignment.rs
@@ -1,0 +1,83 @@
+//! Frame dimensions whose per-slot byte strides are not multiples of
+//! the GPU's storage-buffer offset alignment (32 bytes). A buffer view
+//! bound at such an offset is rejected outright, so these sizes used to
+//! abort the whole pipeline rather than denoise.
+
+use super::helpers::*;
+use crate::nlmeans::*;
+
+fn luma_params(motion_compensation: MotionCompensationMode) -> NlmParams {
+    NlmParams {
+        temporal_radius: 2,
+        search_radius: 2,
+        patch_radius: 1,
+        strength: 1.2,
+        self_weight: 1.0,
+        channels: ChannelMode::Luma,
+        prefilter: PrefilterMode::None,
+        motion_compensation,
+        hq: None,
+    }
+}
+
+/// Pushes five uniform frames and denoises the centre one, asserting
+/// the result is the same uniform value it went in as.
+fn denoise_uniform(w: u32, h: u32, params: NlmParams) {
+    let client = make_client();
+    let frame = make_uniform_frame(w, h, 1, 0.5);
+
+    let mut d = NlmDenoiser::<R>::new(&client, params, w, h);
+    for _ in 0..5 {
+        d.push_frame(&frame);
+    }
+    let result = d.denoise().unwrap().unwrap().to_vec();
+
+    assert_eq!(result.len(), (w * h) as usize);
+    for (i, &v) in result.iter().enumerate() {
+        assert!(
+            (v - 0.5).abs() < 1e-3,
+            "pixel {i}: expected 0.5 (uniform input passthrough), got {v}"
+        );
+    }
+}
+
+#[test]
+fn denoises_when_the_frame_ring_slot_stride_is_unaligned() {
+    // 34x34 luma is 1156 f32 per ring slot, 4624 bytes: a multiple of
+    // 16 but not of 32, so every odd ring slot starts 16 bytes short of
+    // an alignment boundary.
+    denoise_uniform(34, 34, luma_params(MotionCompensationMode::None));
+}
+
+#[test]
+fn denoises_the_nlm_spatial_pilot_when_the_reference_ring_slot_stride_is_unaligned() {
+    // The pilot writes its own output into the reference ring, so at
+    // 34x34 it targets a slot starting 4624 bytes in, 16 short of an
+    // alignment boundary. Only a temporal radius above 0 ever reaches
+    // a slot past the first.
+    let mut params = luma_params(MotionCompensationMode::None);
+    params.prefilter = PrefilterMode::NlmSpatial {
+        strength_scale: DEFAULT_PILOT_STRENGTH_SCALE,
+    };
+    denoise_uniform(34, 34, params);
+}
+
+#[test]
+fn denoises_with_motion_compensation_when_the_pyramid_slot_stride_is_unaligned() {
+    // 42x28 luma sizes the ring slot at 1176 f32 (4704 bytes, a clean
+    // 32-byte multiple), so only the motion pyramid is at stake: its
+    // /2 level is 21x14 = 294 f32 = 1176 bytes, 24 bytes short of a
+    // 32-byte multiple. Same shape as the 720x548 chroma plane that
+    // first hit this.
+    denoise_uniform(
+        42,
+        28,
+        luma_params(MotionCompensationMode::Mvtools {
+            blksize: 8,
+            overlap: 4,
+            search_radius: 2,
+            pyramid_levels: 2,
+            estimation: MotionEstimation::Direct,
+        }),
+    );
+}

--- a/src/nlmeans/tests/alignment.rs
+++ b/src/nlmeans/tests/alignment.rs
@@ -1,7 +1,8 @@
 //! Frame dimensions whose per-slot byte strides are not multiples of
-//! the GPU's storage-buffer offset alignment (32 bytes). A buffer view
-//! bound at such an offset is rejected outright, so these sizes used to
-//! abort the whole pipeline rather than denoise.
+//! the GPU's storage-buffer offset alignment, 32 bytes on the adapters
+//! these tests run against. A buffer view bound at such an offset is
+//! rejected outright, so these sizes used to abort the whole pipeline
+//! rather than denoise.
 
 use super::helpers::*;
 use crate::nlmeans::*;

--- a/src/nlmeans/tests/confidence.rs
+++ b/src/nlmeans/tests/confidence.rs
@@ -5,12 +5,26 @@ use crate::nlmeans::kernels::motion::nlm_mc_block_match_fine;
 use crate::nlmeans::motion::{
     MotionCompensationMode,
     MotionCtx,
+    pyramid_pixels_per_frame,
     run_analyse,
     run_confidence_for_neighbour,
     sad_noise_floor,
     thsad,
 };
 use crate::nlmeans::*;
+
+/// Lays `frames` out as a single-level pyramid buffer, each frame at
+/// the slot stride `run_pyramid_build` writes to. Slots are padded up
+/// to the GPU's storage-buffer offset alignment, so a frame does not
+/// necessarily start right where the one before it ended.
+fn pack_single_level_pyramid(frames: &[&[f32]], width: u32, height: u32) -> Vec<f32> {
+    let stride = pyramid_pixels_per_frame(width, height, 1);
+    let mut data = vec![0.0f32; frames.len() * stride];
+    for (slot, frame) in frames.iter().enumerate() {
+        data[slot * stride..slot * stride + frame.len()].copy_from_slice(frame);
+    }
+    data
+}
 
 /// Runs the fine block-match kernel over a single `blksize × blksize`
 /// block (one cube covers the whole frame, no seed, no search window)
@@ -285,8 +299,9 @@ fn confidence_discriminates_occluded_from_matched_at_prefilter_scale_noise() {
 /// `run_analyse` (the with-MC path) must fill the confidence buffer
 /// with real, in-range values, not leave it at whatever sentinel the
 /// caller pre-seeded it with. Pyramid data is supplied directly rather
-/// than built via `run_pyramid_build`, since a single-level pyramid is
-/// just its two frames concatenated (`[frame0][frame1]`).
+/// than built via `run_pyramid_build`, a single-level pyramid being
+/// just its two frames laid out at the pyramid's own slot stride (see
+/// [`pack_single_level_pyramid`]).
 #[test]
 fn run_analyse_fills_confidence_buffer() {
     let client = make_client();
@@ -309,8 +324,7 @@ fn run_analyse_fills_confidence_buffer() {
 
     let frame0 = noisy_copy(width, 0.5, 4.0 / 255.0, 10);
     let frame1 = noisy_copy(width, 0.5, 4.0 / 255.0, 11);
-    let mut pyramid_data = frame0;
-    pyramid_data.extend(frame1);
+    let pyramid_data = pack_single_level_pyramid(&[&frame0, &frame1], width, height);
     let pyramid = client.create_from_slice(f32::as_bytes(&pyramid_data));
 
     let mv_field = client.empty(mc.mv_slots_per_neighbour() * 2 * size_of::<i32>());
@@ -365,8 +379,7 @@ fn run_confidence_for_neighbour_fills_confidence_buffer() {
 
     let frame0 = noisy_copy(width, 0.5, 4.0 / 255.0, 20);
     let frame1 = noisy_copy(width, 0.5, 4.0 / 255.0, 21);
-    let mut pyramid_data = frame0;
-    pyramid_data.extend(frame1);
+    let pyramid_data = pack_single_level_pyramid(&[&frame0, &frame1], width, height);
     let pyramid = client.create_from_slice(f32::as_bytes(&pyramid_data));
 
     let mv_scratch = client.empty(ctx.mv_slots_per_neighbour() * 2 * size_of::<i32>());

--- a/src/nlmeans/tests/confidence.rs
+++ b/src/nlmeans/tests/confidence.rs
@@ -17,8 +17,8 @@ use crate::nlmeans::*;
 /// the slot stride `run_pyramid_build` writes to. Slots are padded up
 /// to the GPU's storage-buffer offset alignment, so a frame does not
 /// necessarily start right where the one before it ended.
-fn pack_single_level_pyramid(frames: &[&[f32]], width: u32, height: u32) -> Vec<f32> {
-    let stride = pyramid_pixels_per_frame(width, height, 1);
+fn pack_single_level_pyramid(frames: &[&[f32]], width: u32, height: u32, align: StorageAlign) -> Vec<f32> {
+    let stride = pyramid_pixels_per_frame(width, height, 1, align);
     let mut data = vec![0.0f32; frames.len() * stride];
     for (slot, frame) in frames.iter().enumerate() {
         data[slot * stride..slot * stride + frame.len()].copy_from_slice(frame);
@@ -319,12 +319,13 @@ fn run_analyse_fills_confidence_buffer() {
         },
         width,
         height,
+        test_align(),
     )
     .unwrap();
 
     let frame0 = noisy_copy(width, 0.5, 4.0 / 255.0, 10);
     let frame1 = noisy_copy(width, 0.5, 4.0 / 255.0, 11);
-    let pyramid_data = pack_single_level_pyramid(&[&frame0, &frame1], width, height);
+    let pyramid_data = pack_single_level_pyramid(&[&frame0, &frame1], width, height, test_align());
     let pyramid = client.create_from_slice(f32::as_bytes(&pyramid_data));
 
     let mv_field = client.empty(mc.mv_slots_per_neighbour() * 2 * size_of::<i32>());
@@ -375,11 +376,11 @@ fn run_confidence_for_neighbour_fills_confidence_buffer() {
     let height = 16;
     let frame_count = 2;
 
-    let ctx = MotionCtx::confidence_only(width, height);
+    let ctx = MotionCtx::confidence_only(width, height, test_align());
 
     let frame0 = noisy_copy(width, 0.5, 4.0 / 255.0, 20);
     let frame1 = noisy_copy(width, 0.5, 4.0 / 255.0, 21);
-    let pyramid_data = pack_single_level_pyramid(&[&frame0, &frame1], width, height);
+    let pyramid_data = pack_single_level_pyramid(&[&frame0, &frame1], width, height, test_align());
     let pyramid = client.create_from_slice(f32::as_bytes(&pyramid_data));
 
     let mv_scratch = client.empty(ctx.mv_slots_per_neighbour() * 2 * size_of::<i32>());

--- a/src/nlmeans/tests/helpers.rs
+++ b/src/nlmeans/tests/helpers.rs
@@ -1,11 +1,19 @@
 use cubecl::prelude::*;
 use cubecl::wgpu::WgpuRuntime;
 
+pub(super) use crate::nlmeans::align::StorageAlign;
+
 pub(super) type R = WgpuRuntime;
 
 pub(super) fn make_client() -> ComputeClient<R> {
     let device = <R as Runtime>::Device::default();
     R::client(&device)
+}
+
+/// Buffer-binding alignment the test runtime reports, the same value
+/// `NlmDenoiser` lays its per-slot buffers out against.
+pub(super) fn test_align() -> StorageAlign {
+    StorageAlign::from_client(&make_client())
 }
 
 pub(super) fn make_uniform_frame(w: u32, h: u32, ch: u32, val: f32) -> Vec<f32> {

--- a/src/nlmeans/tests/mod.rs
+++ b/src/nlmeans/tests/mod.rs
@@ -1,5 +1,6 @@
 mod helpers;
 
+mod alignment;
 mod confidence;
 mod hq;
 mod motion_compensation;

--- a/src/nlmeans/tests/motion_compensation.rs
+++ b/src/nlmeans/tests/motion_compensation.rs
@@ -548,7 +548,7 @@ fn motion_compensation_1080_square_odd_block_count_dispatch_succeeds() {
         motion_compensation: MotionCompensationMode::mvtools_default(),
         hq: None,
     };
-    let mc = MotionCtx::new(params.motion_compensation, w, h).unwrap();
+    let mc = MotionCtx::new(params.motion_compensation, w, h, test_align()).unwrap();
     assert_eq!(
         mc.blocks_x * mc.blocks_y,
         18225,
@@ -611,7 +611,7 @@ fn motion_compensation_1080_square_odd_block_count_chained_dispatch_succeeds() {
         },
         hq: None,
     };
-    let mc = MotionCtx::new(params.motion_compensation, w, h).unwrap();
+    let mc = MotionCtx::new(params.motion_compensation, w, h, test_align()).unwrap();
     assert_eq!(
         mc.blocks_x * mc.blocks_y,
         18225,
@@ -723,7 +723,7 @@ fn direct_mv_field_for_forward_neighbour(
     d.push_frame(neighbour);
     d.denoise().unwrap();
 
-    let mc = MotionCtx::new(mode, w, h).unwrap();
+    let mc = MotionCtx::new(mode, w, h, test_align()).unwrap();
     let neighbour_idx = neighbour_idx_for_k(1, 1);
     let mv_field = d
         .mv_field_buf
@@ -771,7 +771,7 @@ fn coarse_seeding_handles_equal_grids() {
         pyramid_levels: 2,
         estimation: MotionEstimation::Direct,
     };
-    let mc = MotionCtx::new(mode, w, h).unwrap();
+    let mc = MotionCtx::new(mode, w, h, test_align()).unwrap();
 
     // Recompute `run_analyse`'s coarse-grid formula directly (mirrors
     // `analyse.rs`'s own derivation) rather than trusting the brief's
@@ -843,7 +843,7 @@ fn coarse_seeding_still_correct_at_half_grid() {
         pyramid_levels: 2,
         estimation: MotionEstimation::Direct,
     };
-    let mc = MotionCtx::new(mode, w, h).unwrap();
+    let mc = MotionCtx::new(mode, w, h, test_align()).unwrap();
 
     let coarse_scale = 1u32 << (mc.pyramid_levels - 1);
     let coarse_step = (mc.step / coarse_scale).max(1);
@@ -924,7 +924,7 @@ fn pyramid_level0_extracted_at_one_level() {
         pyramid_levels: 1,
         estimation: MotionEstimation::Direct,
     };
-    let mc = MotionCtx::new(mode, w, h).unwrap();
+    let mc = MotionCtx::new(mode, w, h, test_align()).unwrap();
 
     let world = noisy_copy(w, 0.5, 0.2, 77);
     let shifted = frame_shifted_by(&world, w, h, dx, dy);
@@ -1008,7 +1008,7 @@ fn coarse_seeding_covers_ragged_last_block() {
     // `(shift, shift)` translation and returns it alongside the
     // `MotionCtx` used to index it.
     let build = |w: u32, h: u32| -> (MotionCtx, Vec<i32>) {
-        let mc = MotionCtx::new(mode, w, h).unwrap();
+        let mc = MotionCtx::new(mode, w, h, test_align()).unwrap();
         let world = make_noisy_gaussian_frame(w, h, 1, 0.5, &[0.2]);
         let shifted = frame_shifted_by(&world, w, h, shift, shift);
         let data = direct_mv_field_for_forward_neighbour(mode, w, h, &world, &shifted);
@@ -1186,7 +1186,7 @@ fn composed_centre_mv(d: &NlmDenoiser<R>, radius: u32, k: i32) -> (i32, i32) {
     d.run_chain_compose(radius, k)
         .expect("chain compose dispatch failed");
 
-    let mc = MotionCtx::new(d.params.motion_compensation, d.width, d.height).unwrap();
+    let mc = MotionCtx::new(d.params.motion_compensation, d.width, d.height, d.align).unwrap();
     let neighbour_idx = neighbour_idx_for_k(radius, k);
     let mv_field = d
         .mv_field_buf
@@ -1209,7 +1209,7 @@ fn composed_centre_mv(d: &NlmDenoiser<R>, radius: u32, k: i32) -> (i32, i32) {
 /// duplicated slots (priming or flush), whose pair is zero motion by
 /// definition.
 fn assert_pair_ring_zero_from(d: &NlmDenoiser<R>, ring_head_before: i32, radius: u32) {
-    let mc = MotionCtx::new(d.params.motion_compensation, d.width, d.height).unwrap();
+    let mc = MotionCtx::new(d.params.motion_compensation, d.width, d.height, d.align).unwrap();
     let pair_ring = d
         .pair_ring_buf
         .as_ref()

--- a/src/nlmeans/tests/temporal_noise.rs
+++ b/src/nlmeans/tests/temporal_noise.rs
@@ -34,7 +34,8 @@ fn run_temporal_stats(w: u32, h: u32, stored_ch: u32, prev: &[f32], new: &[f32])
     ring[frame_len..].copy_from_slice(new);
 
     let input_buf = client.create_from_slice(f32::as_bytes(&ring));
-    let stats_buf = client.empty(temporal_stats_buf_bytes(w, h, stored_ch, frame_count));
+    let align = test_align();
+    let stats_buf = client.empty(temporal_stats_buf_bytes(w, h, stored_ch, frame_count, align));
 
     let ctx = TemporalStatsCtx {
         width: w,
@@ -45,10 +46,11 @@ fn run_temporal_stats(w: u32, h: u32, stored_ch: u32, prev: &[f32], new: &[f32])
         slot_prev: 0,
         input_buf: &input_buf,
         stats_buf: &stats_buf,
+        align,
     };
     run_temporal_noise_stats::<R>(&client, &ctx).expect("temporal noise stats dispatch failed");
 
-    read_temporal_stats_slot::<R>(&client, &stats_buf, w, h, stored_ch, frame_count, 1)
+    read_temporal_stats_slot::<R>(&client, &stats_buf, w, h, stored_ch, frame_count, 1, align)
         .expect("readback failed")
 }
 


### PR DESCRIPTION
Fixes memory alignment errors when enabling motion compensation and when device has non-32byte aligned memory requirements.