### PR TITLE
Gracefully handle FFMS's phantom frame generation 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ cubecl.log
 /**/*.bpk
 /.claude/
 /scripts/**/*.pyc
+/workspaces

--- a/.idea/av-denoise.iml
+++ b/.idea/av-denoise.iml
@@ -14,6 +14,7 @@
       <sourceFolder url="file://$MODULE_DIR$/packages/vs-avd/src" isTestSource="false" />
       <excludeFolder url="file://$MODULE_DIR$/packages/vs-avd/.venv" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
+      <excludeFolder url="file://$MODULE_DIR$/workspaces/vs-scripting/.venv" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,6 +188,7 @@ dependencies = [
  "av-denoise-core",
  "av-scenechange",
  "clap",
+ "ffms2-sys",
  "indicatif",
  "mimalloc",
  "strum",

--- a/av-denoise/Cargo.toml
+++ b/av-denoise/Cargo.toml
@@ -39,6 +39,9 @@ strum_macros.workspace = true
 # Frame ingestion via ffms2
 av-scenechange = { version = "0.23", optional = true, features = ["ffms2"] }
 av-decoders = { version = "0.9", optional = true, features = ["ffms2"] }
+# Reads the frame index av-decoders does not surface. Must track the
+# ffms2-sys that av-decoders links, so both share one set of handles.
+ffms2-sys = { version = "0.3", optional = true }
 v_frame = { version = "0.5", optional = true }
 
 # Frame ingestion via y4m stdin
@@ -61,6 +64,7 @@ binary = [
     "mimalloc",
     "av-scenechange",
     "av-decoders",
+    "ffms2-sys",
     "v_frame",
     "y4m",
     "indicatif",

--- a/av-denoise/src/bin/file_mode.rs
+++ b/av-denoise/src/bin/file_mode.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::io::{IsTerminal, stdout};
 use std::path::Path;
 use std::sync::mpsc::{Receiver, SyncSender, sync_channel};
@@ -12,6 +12,7 @@ use indicatif::ProgressBar;
 use y4m::Frame as Y4mFrame;
 
 use crate::cli::RunOptions;
+use crate::frame_index;
 use crate::progress::{self, denoise_bar_visible, denoise_progress_bar, scene_progress_bar};
 use crate::y4m_format::subsampling_to_y4m;
 
@@ -86,10 +87,17 @@ fn channel_budget(layout: FrameLayout, workers: usize) -> ChannelBudget {
 struct SceneLayout {
     layout: FrameLayout,
     framerate: Rational32,
+    /// Frames this run emits, being `raw_frames` less the phantom entries.
     total_frames: usize,
-    /// `scene_starts[i]` is the inclusive start frame of scene `i`. The
-    /// final entry is `total_frames` so scene `i` covers
-    /// `scene_starts[i] .. scene_starts[i + 1]`.
+    /// Frames the decoder hands over, phantom entries included. Every
+    /// one has to be read to keep the sequential decoder in step, even
+    /// though only `total_frames` of them are emitted.
+    raw_frames: usize,
+    /// Decoder frame numbers that carry no picture of their own. See
+    /// [`crate::frame_index`].
+    phantom: BTreeSet<usize>,
+    /// `scene_starts[i]` is the inclusive start frame of scene `i`, in  emitted frame numbers.
+    /// The final entry is `total_frames` so scene `i` covers `scene_starts[i]..scene_starts[i + 1]`.
     scene_starts: Vec<usize>,
 }
 
@@ -154,6 +162,19 @@ fn detect_scenes(input: &Path, visible: bool) -> Result<SceneLayout, anyhow::Err
         "running scene detection",
     );
 
+    // Read the index before decoding anything. This only inspects the
+    // metadata ffms2 already built, so it costs nothing.
+    let phantom = frame_index::read_index(&mut decoder)
+        .map(|index| frame_index::phantom_indices(&index))
+        .unwrap_or_default();
+
+    if !phantom.is_empty() {
+        tracing::info!(
+            dropped = phantom.len(),
+            "the decoder reports frames that carry no picture of their own, dropping them",
+        );
+    }
+
     let pb = scene_progress_bar(details.total_frames, visible);
     let on_progress = |frames_analyzed: usize, _keyframe_count: usize| {
         pb.set_position(frames_analyzed as u64);
@@ -177,13 +198,24 @@ fn detect_scenes(input: &Path, visible: bool) -> Result<SceneLayout, anyhow::Err
         scene_starts.insert(0, 0);
     }
 
-    let total_frames = detection.frame_count;
-    scene_starts.push(total_frames);
+    // Detection ran over every frame the decoder offers, so both the count and the boundaries
+    // are in decoder frame numbers. Both move into emitted frame numbers together.
+    let raw_frames = detection.frame_count;
+    scene_starts.push(raw_frames);
+
+    let scene_starts = frame_index::remap_scene_starts(&scene_starts, &phantom);
+    let total_frames = raw_frames - phantom.len();
+
+    if total_frames == 0 {
+        anyhow::bail!("{} holds no decodable frames", input.display());
+    }
 
     Ok(SceneLayout {
         layout,
         framerate: details.frame_rate,
         total_frames,
+        raw_frames,
+        phantom,
         scene_starts,
     })
 }
@@ -300,13 +332,11 @@ fn dispatch_frames(
 
     let mut scene_idx = 0usize;
     let mut next_boundary = scenes.scene_starts[1];
+    let mut g = 0u64;
 
-    for g in 0..scenes.total_frames {
-        while g >= next_boundary && scene_idx + 1 < scenes.scene_count() {
-            scene_idx += 1;
-            next_boundary = scenes.scene_starts[scene_idx + 1];
-        }
-
+    for raw in 0..scenes.raw_frames {
+        // Every frame is read, phantom or not. The decoder walks the file in order and has
+        // no way to be told to skip one.
         let planes = match scenes.layout.depth {
             Depth::Eight => {
                 let frame = decoder.read_video_frame::<u8>()?;
@@ -317,15 +347,30 @@ fn dispatch_frames(
                 planes_from_v_frame_u16(&frame, scenes.layout)
             },
         };
+
+        // A phantom frame repeats one of its neighbours. Emitting it would lengthen the output
+        // and shift everything after it, and feeding it to a worker would put a false
+        // still frame into the temporal window.
+        if scenes.phantom.contains(&raw) {
+            continue;
+        }
+
+        while g >= next_boundary as u64 && scene_idx + 1 < scenes.scene_count() {
+            scene_idx += 1;
+            next_boundary = scenes.scene_starts[scene_idx + 1];
+        }
+
         let target = scene_idx % workers;
 
         worker_txs[target]
             .send(WorkerMsg::Frame {
-                global_idx: g as u64,
+                global_idx: g,
                 scene_idx: scene_idx as u32,
                 planes,
             })
             .map_err(|_| anyhow::anyhow!("worker {target} disconnected"))?;
+
+        g += 1;
     }
 
     Ok(())

--- a/av-denoise/src/bin/frame_index.rs
+++ b/av-denoise/src/bin/frame_index.rs
@@ -1,0 +1,199 @@
+use std::collections::BTreeSet;
+
+use av_decoders::Decoder;
+use ffms2_sys::{FFMS_GetFrameInfo, FFMS_GetTrackFromVideo};
+
+/// One entry of the ffms2 video index.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct IndexEntry {
+    /// Presentation timestamp, in the video track's time base.
+    pub pts: i64,
+    /// Whether ffms2 marked this entry as a keyframe.
+    pub keyframe: bool,
+}
+
+/// Reads the video index behind `decoder`.
+///
+/// Returns `None` when `decoder` is not backed by ffms2, or when ffms2 declines to describe the
+/// track, when this happens caller then keeps every frame.
+pub fn read_index(decoder: &mut Decoder) -> Option<Vec<IndexEntry>> {
+    let total = decoder.get_video_details().total_frames?;
+    let source = decoder.get_ffms2_impl()?.video_source;
+
+    // SAFETY: a live `Ffms2Decoder` holds a non-null video source, and
+    // the track belongs to that source rather than to us, so it stays
+    // valid for as long as the decoder does.
+    let track = unsafe { FFMS_GetTrackFromVideo(source) };
+
+    if track.is_null() {
+        return None;
+    }
+
+    let mut index = Vec::with_capacity(total);
+
+    for i in 0..total {
+        // SAFETY: `track` is non-null, and `i` stays below the frame
+        // count ffms2 reported for this track.
+        let info = unsafe { FFMS_GetFrameInfo(track, i as i32) };
+
+        if info.is_null() {
+            return None;
+        }
+
+        // SAFETY: checked non-null just above.
+        let info = unsafe { &*info };
+
+        index.push(IndexEntry {
+            pts: info.PTS,
+            keyframe: info.KeyFrame != 0,
+        });
+    }
+
+    Some(index)
+}
+
+/// Returns the index positions that carry no picture of their own.
+pub fn phantom_indices(index: &[IndexEntry]) -> BTreeSet<usize> {
+    let mut phantom = BTreeSet::new();
+
+    if index.is_empty() {
+        return phantom;
+    }
+
+    // Nothing before the first keyframe can be decoded, so ffms2
+    // answers those positions with a repeat of the keyframe.
+    let lead = index.iter().position(|e| e.keyframe).unwrap_or(0);
+    phantom.extend(0..lead);
+
+    let mut gaps: Vec<i64> = (lead + 1..index.len())
+        .map(|i| index[i].pts - index[i - 1].pts)
+        .collect();
+
+    if gaps.is_empty() {
+        return phantom;
+    }
+
+    // The median gap is the clip's real frame spacing. A handful of
+    // phantom entries cannot move it, however far apart they sit.
+    gaps.sort_unstable();
+    let threshold = gaps[gaps.len() / 2] / 2;
+
+    // A phantom shares a timeline slot with the frame that follows it,
+    // landing just ahead of that frame's timestamp. The entry to drop
+    // is therefore the earlier of the pair.
+    for i in lead + 1..index.len() {
+        if index[i].pts - index[i - 1].pts < threshold {
+            phantom.insert(i - 1);
+        }
+    }
+
+    phantom
+}
+
+/// Rewrites scene boundaries from ffms2 index space into the output
+/// frame numbering that dropping `phantom` produces.
+///
+/// A boundary that lands on a dropped entry moves onto the next frame that survives,
+/// which can leave it equal to its neighbour. Those collapse, because a scene cannot
+/// start where the one before it does.
+pub fn remap_scene_starts(starts: &[usize], phantom: &BTreeSet<usize>) -> Vec<usize> {
+    let mut out: Vec<usize> = starts
+        .iter()
+        .map(|&raw| raw - phantom.range(..raw).count())
+        .collect();
+
+    out.dedup();
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Builds an index at a steady 42-unit spacing, with the first entry marked as the keyframe.
+    fn regular(count: usize) -> Vec<IndexEntry> {
+        (0..count)
+            .map(|i| IndexEntry {
+                pts: i as i64 * 42,
+                keyframe: i == 0,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn a_regular_index_has_no_phantoms() {
+        assert!(phantom_indices(&regular(20)).is_empty());
+    }
+
+    #[test]
+    fn an_empty_index_has_no_phantoms() {
+        assert!(phantom_indices(&[]).is_empty());
+    }
+
+    #[test]
+    fn entries_before_the_first_keyframe_are_phantom() {
+        let mut index = vec![IndexEntry {
+            pts: 0,
+            keyframe: false,
+        }];
+        index.extend((1..20).map(|i| IndexEntry {
+            pts: 41 + (i as i64 - 1) * 42,
+            keyframe: i == 1,
+        }));
+
+        assert_eq!(phantom_indices(&index), BTreeSet::from([0]));
+    }
+
+    #[test]
+    fn the_earlier_entry_of_a_too_close_pair_is_phantom() {
+        let mut index = vec![
+            IndexEntry {
+                pts: 0,
+                keyframe: true,
+            },
+            IndexEntry {
+                pts: 41,
+                keyframe: false,
+            },
+            IndexEntry {
+                pts: 42,
+                keyframe: false,
+            },
+            IndexEntry {
+                pts: 82,
+                keyframe: false,
+            },
+            IndexEntry {
+                pts: 84,
+                keyframe: false,
+            },
+        ];
+        index.extend((5..20).map(|i| IndexEntry {
+            pts: 125 + (i as i64 - 5) * 42,
+            keyframe: false,
+        }));
+
+        assert_eq!(phantom_indices(&index), BTreeSet::from([1, 3]));
+    }
+
+    #[test]
+    fn repeated_pictures_at_regular_spacing_are_kept() {
+        assert!(phantom_indices(&regular(2159)).is_empty());
+    }
+
+    #[test]
+    fn remap_shifts_boundaries_past_each_dropped_entry() {
+        let phantom = BTreeSet::from([1, 3]);
+
+        // Raw 0 stays put. Raw 2 loses the one phantom below it, raw 5
+        // loses both.
+        assert_eq!(remap_scene_starts(&[0, 2, 5], &phantom), vec![0, 1, 3]);
+    }
+
+    #[test]
+    fn remap_collapses_a_boundary_that_lands_on_a_dropped_entry() {
+        // Raw 1 is itself dropped, so it maps onto the same output
+        // frame as raw 2. The duplicate boundary must not survive.
+        assert_eq!(remap_scene_starts(&[0, 1, 2], &BTreeSet::from([1])), vec![0, 1]);
+    }
+}

--- a/av-denoise/src/bin/main.rs
+++ b/av-denoise/src/bin/main.rs
@@ -3,6 +3,7 @@ use tracing_subscriber::EnvFilter;
 
 mod cli;
 mod file_mode;
+mod frame_index;
 mod progress;
 mod stream_mode;
 mod y4m_format;


### PR DESCRIPTION
When FFMS hits b-frames and other frames it cannot decode, it duplicates the prior frame in its place and inserts its own timestamp. 

This causes us some issue in cases where you have a video which has been cropped uncleanly or has frames that can't be decoded because the resulting output will have N frames more than the source, which will cause the decoders to disagree.